### PR TITLE
refactoring dataloader.py

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,6 +9,8 @@ SDOML dataset
     :target: https://dl.circleci.com/status-badge/redirect/gh/PaulJWright/sdoml/tree/develop
     :alt: CICD Status
 
+.. image:: https://mybinder.org/badge_logo.svg
+ :target: https://mybinder.org/v2/gh/pauljwright/sdoml/develop?urlpath=https%3A%2F%2Fgithub.com%2FPaulJWright%2Fsdoml%2Ftree%2Fdevelop%2Fexamples%2Fdataset
 
 SDOML is an open-source package for working with the SDOML Dataset (`sdoml.org <https://sdoml.org>`_).
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -47,18 +47,24 @@ extensions = [
     # 'sphinx.ext.autosummary',
     "sphinx_rtd_theme",
     # 'sphinx_gallery.gen_gallery',
-    "sphinx_copybutton",
+    # "sphinx_copybutton",
     "nbsphinx",
     "nbsphinx_link",
     "sphinx.ext.graphviz",
+    "sphinx_toggleprompt",
 ]
 
+# graphviz output as "svg"
 graphviz_output_format = "svg"
+
+# move `>>>` 35 stops to the right
+# https://sphinx-toggleprompt.readthedocs.io/en/stable/
+# toggleprompt_offset_right = 35
 
 #
 # https://nbsphinx.readthedocs.io/en/0.6.1/usage.html
 nbsphinx_execute_arguments = [
-    "--InlineBackend.figure_formats={'png'}",
+    "--InlineBackend.figure_formats={'svg', 'pdf'}",
     "--InlineBackend.rc={'figure.dpi': 96}",
 ]
 
@@ -90,6 +96,7 @@ intersphinx_mapping = {
     "matplotlib": ("https://matplotlib.org/stable", None),
     "aiapy": ("https://aiapy.readthedocs.io/en/stable/", None),
     "sunpy": ("https://docs.sunpy.org/en/stable/", None),
+    "typing": ("https://typing.readthedocs.io/en/latest/", None),
 }
 
 # -- Options for HTML output -------------------------------------------------

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -13,7 +13,7 @@ To use ``sdoml``, first install it using pip:
    cd sdoml
    pip install -e .
 
-If you would like to access and use the data stored on the Google Cloud Platform, you may need to install the Google Cloud Command Line Interface (gcloud CLI). After install, you may need to run the following commands:
+If you would like to access and use the data stored on the Google Cloud Platform, you may need to install the Google Cloud Command Line Interface (`gcloud CLI <https://cloud.google.com/sdk/docs/install>`_). After install, you may need to run the following commands:
 
 .. code-block:: console
 

--- a/docs/source/sdoml/dataloader.rst
+++ b/docs/source/sdoml/dataloader.rst
@@ -22,6 +22,7 @@ objects (see :ref:`sources`).
    :inherited-members:
    :no-inheritance-diagram:
 
+
 Example
 -------
 

--- a/docs/source/sdoml/dataloader.rst
+++ b/docs/source/sdoml/dataloader.rst
@@ -26,10 +26,12 @@ creation of ``datasource_arr`` was described in :doc:`sources`.
 
 .. code-block:: python
 
+   from sdoml import SDOMLDataset
+
    sdomlds = SDOMLDataset(
       cache_max_size=1 * 512 * 512 * 4096,
       years=["2010"],
-      data_to_load=datasource_arr, # this is a List[DataSource]
+      data_to_load=datasource_arr, # this is a List[``sdo.sources.DataSource``]
    )
 
 ``sdomlds`` can then be used as any other dataloader. If caching is implemented,

--- a/docs/source/sdoml/dataloader.rst
+++ b/docs/source/sdoml/dataloader.rst
@@ -1,8 +1,8 @@
 .. _dataloader:
 
-=======================================
-SDOML Dataloader (``sdoml.dataloader``)
-=======================================
+=================================
+Dataloader (``sdoml.dataloader``)
+=================================
 
 .. toctree::
    :maxdepth: 1
@@ -19,33 +19,26 @@ exists, that type is used. If there are ``0`` or ``>=1`` matches,
 :py:meth:`~sunpy.map.map_factory.NoMatchError` or
 :py:meth:`~sunpy.map.map_factory.MultipleMatchError` will be raised.
 
-For example, to load HMI (Bx, By, Bz), AIA (94A, 131A), and EVE (O V, Fe XI) for
+For example, to load HMI (Bx, By, Bz), AIA (94 Å, 131 Å), and EVE (O V, Fe XI) for
 2010, located in Google Cloud Storage (``gcs``)
-:py:meth:`~sdoml.dataloader.SDOMLDataset` can be called as follows:
+:py:meth:`~sdoml.dataloader.SDOMLDataset` can be called as follows, where the
+creation of ``datasource_arr`` was described in :doc:`sources`.
 
 .. code-block:: python
 
    sdomlds = SDOMLDataset(
       cache_max_size=1 * 512 * 512 * 4096,
       years=["2010"],
-      data_to_load={
-         "HMI": {
-               "storage_location": "gcs",
-               "root": "fdl-sdoml-v2/sdomlv2_hmi_small.zarr/",
-               "channels": ["Bx", "By", "Bz"],
-         },
-         "AIA": {
-               "storage_location": "gcs",
-               "root": "fdl-sdoml-v2/sdomlv2_small.zarr/",
-               "channels": ["94A", "131A"],
-         },
-         "EVE": {
-               "storage_location": "gcs",
-               "root": "fdl-sdoml-v2/sdomlv2_eve.zarr/",
-               "channels": ["O V", "Fe XI"],
-         },
-      },
+      data_to_load=datasource_arr, # this is a List[DataSource]
    )
+
+``sdomlds`` can then be used as any other dataloader. If caching is implemented,
+the second request on an index will be quicker. e.g.:
+
+.. code-block:: python
+
+   >>> first ``sdomlds.__getitem__(0)`` request took 69.02 seconds
+   >>> second ``sdomlds.__getitem__(0)`` request took 0.54 seconds
 
 .. warning::
    The API is not stable, and is subject to change.

--- a/docs/source/sdoml/dataloader.rst
+++ b/docs/source/sdoml/dataloader.rst
@@ -7,45 +7,47 @@ Dataloader (``sdoml.dataloader``)
 .. toctree::
    :maxdepth: 1
 
-The initial implementation of ``sdoml`` provides a single dataloader
+This initial implementation of ``sdoml`` provides a single torch dataloader
 class for the SDOML v2+ data located on the Google Cloud Platform.
 
-The :py:meth:`~sdoml.dataloader.SDOMLDataset` instantiates ``DataSource``
-objects (see :ref:`sources`). When called,
-:py:meth:`~sdoml.sources.dataset_factory.DataSource` utilises the
-:py:meth:`~sdoml.sources.dataset_factory.DataSourceFactory` to instantiate one
-of the registered types which match the arguments provided. If the match
-exists, that type is used. If there are ``0`` or ``>=1`` matches,
-:py:meth:`~sunpy.map.map_factory.NoMatchError` or
-:py:meth:`~sunpy.map.map_factory.MultipleMatchError` will be raised.
-
-For example, to load HMI (Bx, By, Bz), AIA (94 Å, 131 Å), and EVE (O V, Fe XI) for
-2010, located in Google Cloud Storage (``gcs``)
-:py:meth:`~sdoml.dataloader.SDOMLDataset` can be called as follows, where the
-creation of ``datasource_arr`` was described in :doc:`sources`.
-
-.. code-block:: python
-
-   from sdoml import SDOMLDataset
-
-   sdomlds = SDOMLDataset(
-      cache_max_size=1 * 512 * 512 * 4096,
-      years=["2010"],
-      data_to_load=datasource_arr, # this is a List[``sdo.sources.DataSource``]
-   )
-
-``sdomlds`` can then be used as any other dataloader. If caching is implemented,
-the second request on an index will be quicker. e.g.:
-
-.. code-block:: python
-
-   >>> first ``sdomlds.__getitem__(0)`` request took 69.02 seconds
-   >>> second ``sdomlds.__getitem__(0)`` request took 0.54 seconds
+The :py:meth:`~sdoml.dataloader.SDOMLDataset` accepts a List of ``DataSource``
+objects (see :ref:`sources`).
 
 .. warning::
    The API is not stable, and is subject to change.
 
 .. automodapi:: sdoml.dataloader
+   :no-heading:
    :include-all-objects:
    :inherited-members:
    :no-inheritance-diagram:
+
+Example
+-------
+
+If the user wishes to load HMI (Bx, By, Bz), AIA (94 Å, 131 Å), and EVE (O V, Fe XI) from the year 2010,
+:py:meth:`~sdoml.dataloader.SDOMLDataset` can be called as follows, where the
+creation of ``datasource_arr`` was described in :doc:`sources`.
+
+.. code-block:: python
+
+   >>> from sdoml import SDOMLDataset
+   >>> sdomlds = SDOMLDataset(
+   ...    cache_max_size=1 * 512 * 512 * 4096,
+   ...    years=["2010"],
+   ...    data_to_load=datasource_arr, # this is a List[``sdo.sources.DataSource``]
+   ... )
+   >>> dataloader = torch.utils.data.DataLoader(
+   ...    sdomlds,
+   ...    batch_size=1,
+   ...    shuffle=False,
+   ... )
+
+For detailed examples see, :doc:`examples/index`.
+
+.. note::
+
+   If caching is implemented, the second request on an index will be quicker. e.g.:
+
+   >>> first ``sdomlds.__getitem__(0)`` request took 69.02 seconds
+   >>> second ``sdomlds.__getitem__(0)`` request took 0.54 seconds

--- a/docs/source/sdoml/factory.rst
+++ b/docs/source/sdoml/factory.rst
@@ -1,0 +1,10 @@
+.. .. _sources_dataset_factory:
+
+.. ================================================
+.. Data Sources (``sdoml.sources.dataset_factory``)
+.. ================================================
+
+.. .. automodapi:: sdoml.sources.dataset_factory
+..    :include-all-objects:
+..    :inherited-members:
+..    :no-main-docstr:

--- a/docs/source/sdoml/sources.rst
+++ b/docs/source/sdoml/sources.rst
@@ -33,12 +33,14 @@ e.g. for :py:meth:`~sdoml.sources.sdoml_gcs.SDOML_AIA_GCS`, this is:
          and Path(str(meta["root"])).name == "sdomlv2_small.zarr"
       )
 
-where upon instantiation of the :py:meth:`~sdoml.sources.dataset_factory.DataSource`,
+where upon instantiation of the :py:meth:`~sdoml.sources.DataSource`,
 if the instrument name is  ``aia``, the storage location ``gcs``, and the
 ``.zarr`` file, ``sdomlv2_small.zarr``, :py:meth:`~sdoml.sources.sdoml_gcs.SDOML_AIA_GCS`
 will be instantiated.
 
 .. code-block:: python
+
+   from sdoml.sources import DataSource
 
    data_to_load = {
       "HMI": {

--- a/docs/source/sdoml/sources.rst
+++ b/docs/source/sdoml/sources.rst
@@ -1,22 +1,81 @@
 .. _sources:
 
 ================================
-Data Sources (``sdoml.sources``)
+Data Sources (``sdoml.sources.DataSource``)
 ================================
 
 .. toctree::
    :maxdepth: 1
 
-Currently, ``sdoml`` contains a small number of available data sources,
-prefixed with ``SDOML``, that inherit from
-:py:meth:`~sdoml.sources.data_base.GenericDataSource`.
+One of the core classes in ``sdoml`` is a `DataSource`. An ``sdoml`` DataSource
+object provides information on the location and storage of the data.
+These DataSource objects are subclasses of the :py:meth:`~sdoml.sources.data_base.GenericDataSource`
+and are created using the DataSource factory, :py:meth:`~sdoml.sources.DataSource`.
 
-Here, :py:meth:`~sdoml.sources.data_base.GenericDataSource` is a generic ``DataSource``
-class from which all other ``DataSource`` classes inherit from.
-Each of the children have a `datasource` method,
-e.g. :py:meth:`~sdoml.sources.sdoml_gcs.SDOML_AIA_GCS.datasource`,
-which provides information on what input parameters will lead to class instantiation
-e.g. for :py:meth:`~sdoml.sources.sdoml_gcs.SDOML_AIA_GCS`, this is:
+``sdoml`` currently supports a small number data sources, see :ref:`available-datasource-classes` for a list of them.
+
+.. warning::
+   The API is not stable, and is subject to change.
+
+.. _available-datasource-classes:
+
+Available ``DataSource`` classes
+--------------------------------
+
+The available set of DataSource objects that can be instantiated by
+:py:meth:`~sdoml.sources.DataSource` are as described below,
+with an accompanying inheritance diagram.
+
+.. automodapi:: sdoml.sources.sdoml_gcs
+   :no-heading:
+   :inheritance-diagram:
+   :no-main-docstr:
+
+.. note::
+
+   Instrument-specific subclasses should not be instantiated. Instead, call
+   :py:meth:`~sdoml.sources.DataSource` with the appropriate arguments,
+   and let the appropriate subclass be instantiated!
+
+
+Example
+-------
+
+If the user wishes to load HMI (Bx, By, Bz), AIA (94 Å, 131 Å), and EVE (O V, Fe XI),
+:py:meth:`~sdoml.sources.DataSource` should be called as follows for each instrument.
+
+The ``DataSource`` objects should be assigned in a `List`, e.g. ``datasource_arr``.
+This ``List[DataSource]`` can be passed to the ``sdoml.dataloader.SDOMLDataset`` class, as discussed in
+:doc:`dataloader`.
+
+
+   >>> from sdoml.sources import DataSource
+   >>> data_to_load = {
+   ...    "HMI": {
+   ...          "storage_location": "gcs",
+   ...          "root": "fdl-sdoml-v2/sdomlv2_hmi_small.zarr/",
+   ...          "channels": ["Bx", "By", "Bz"],
+   ...    },
+   ...    "AIA": {
+   ...          "storage_location": "gcs",
+   ...          "root": "fdl-sdoml-v2/sdomlv2_small.zarr/",
+   ...          "channels": ["94A", "131A"],
+   ...    },
+   ...    "EVE": {
+   ...          "storage_location": "gcs",
+   ...          "root": "fdl-sdoml-v2/sdomlv2_eve.zarr/",
+   ...          "channels": ["O V", "Fe XI"],
+   ...    },
+   ... }
+   >>> datasource_arr = [DataSource(instrument=k, meta=v) for k, v in data_to_load.items()]
+
+Writing a new DataSource class
+------------------------------
+
+A subclass of :py:meth:`~sdoml.sources.data_base.GenericDataSource` with the
+``datasource`` method, will be registered with the
+:py:meth:`~sdoml.sources.DataSource` factory. An example of the `datasource`
+method, for :py:meth:`~sdoml.sources.sdoml_gcs.SDOML_AIA_GCS` is shown below:
 
 .. code-block:: python
 
@@ -38,34 +97,18 @@ if the instrument name is  ``aia``, the storage location ``gcs``, and the
 ``.zarr`` file, ``sdomlv2_small.zarr``, :py:meth:`~sdoml.sources.sdoml_gcs.SDOML_AIA_GCS`
 will be instantiated.
 
+In addition to the ``datasource`` method, the following attributes
+should be set in the subclass:
+
 .. code-block:: python
 
-   from sdoml.sources import DataSource
+   self._time_format : str                 # e.g. %Y-%m-%dT%H:%M:%S.%fZ
 
-   data_to_load = {
-      "HMI": {
-            "storage_location": "gcs",
-            "root": "fdl-sdoml-v2/sdomlv2_hmi_small.zarr/",
-            "channels": ["Bx", "By", "Bz"],
-      },
-      "AIA": {
-            "storage_location": "gcs",
-            "root": "fdl-sdoml-v2/sdomlv2_small.zarr/",
-            "channels": ["94A", "131A"],
-      },
-      "EVE": {
-            "storage_location": "gcs",
-            "root": "fdl-sdoml-v2/sdomlv2_eve.zarr/",
-            "channels": ["O V", "Fe XI"],
-      },
-   }
+   # as a result of the abstractmethod ``self._get_years_channels()``
+   self._available_years : List[str]       # e.g. ['2010','2011', ...]
+   self._available_channels : List[str]    # e.g. ['94A', '131A', ...]
 
-   years = ["2010", "2011"]
-   cache_max_size = 1 * 512 * 512 * 2048
-
-   datasource_arr = [DataSource(instrument=k, meta=v) for k, v in data_to_load.items()]
-
-.. automodapi:: sdoml.sources
-   :include-all-objects:
-   :inherited-members:
-   :no-main-docstr:
+   # as a result of the abstractmethod ``self.load_data_meta()``
+   self._data_by_year : List
+   self._meta_by_year : List
+   self._time_by_year : np.ndarray

--- a/docs/source/sdoml/sources.rst
+++ b/docs/source/sdoml/sources.rst
@@ -37,7 +37,6 @@ where upon instantiation of the DataSource, if the instrument name is  ``aia``,
 the storage location ``gcs``, and the ``.zarr`` file, ``sdomlv2_small.zarr``,
 :py:meth:`~sdoml.sources.sdoml_gcs.SDOML_AIA_GCS` will be instantiated.
 
-
 .. code-block:: python
 
    data_to_load = {
@@ -61,10 +60,7 @@ the storage location ``gcs``, and the ``.zarr`` file, ``sdomlv2_small.zarr``,
    years = ["2010", "2011"]
    cache_max_size = 1 * 512 * 512 * 2048
 
-   data_arr = [
-      DataSource(k, v, years, cache_max_size/len(data_to_load.items()))
-      for k, v in data_to_load.items()
-   ]
+   datasource_arr = [DataSource(instrument=k, meta=v) for k, v in data_to_load.items()]
 
 .. automodapi:: sdoml.sources
    :include-all-objects:

--- a/docs/source/sdoml/sources.rst
+++ b/docs/source/sdoml/sources.rst
@@ -40,6 +40,24 @@ the storage location ``gcs``, and the ``.zarr`` file, ``sdomlv2_small.zarr``,
 
 .. code-block:: python
 
+   data_to_load = {
+      "HMI": {
+            "storage_location": "gcs",
+            "root": "fdl-sdoml-v2/sdomlv2_hmi_small.zarr/",
+            "channels": ["Bx", "By", "Bz"],
+      },
+      "AIA": {
+            "storage_location": "gcs",
+            "root": "fdl-sdoml-v2/sdomlv2_small.zarr/",
+            "channels": ["94A", "131A"],
+      },
+      "EVE": {
+            "storage_location": "gcs",
+            "root": "fdl-sdoml-v2/sdomlv2_eve.zarr/",
+            "channels": ["O V", "Fe XI"],
+      },
+   }
+
    years = ["2010", "2011"]
    cache_max_size = 1 * 512 * 512 * 2048
 

--- a/docs/source/sdoml/sources.rst
+++ b/docs/source/sdoml/sources.rst
@@ -37,6 +37,17 @@ where upon instantiation of the DataSource, if the instrument name is  ``aia``,
 the storage location ``gcs``, and the ``.zarr`` file, ``sdomlv2_small.zarr``,
 :py:meth:`~sdoml.sources.sdoml_gcs.SDOML_AIA_GCS` will be instantiated.
 
+
+.. code-block:: python
+
+   years = ["2010", "2011"]
+   cache_max_size = 1 * 512 * 512 * 2048
+
+   data_arr = [
+      DataSource(k, v, years, cache_max_size/len(data_to_load.items()))
+      for k, v in data_to_load.items()
+   ]
+
 .. automodapi:: sdoml.sources
    :include-all-objects:
    :inherited-members:

--- a/docs/source/sdoml/sources.rst
+++ b/docs/source/sdoml/sources.rst
@@ -33,9 +33,10 @@ e.g. for :py:meth:`~sdoml.sources.sdoml_gcs.SDOML_AIA_GCS`, this is:
          and Path(str(meta["root"])).name == "sdomlv2_small.zarr"
       )
 
-where upon instantiation of the DataSource, if the instrument name is  ``aia``,
-the storage location ``gcs``, and the ``.zarr`` file, ``sdomlv2_small.zarr``,
-:py:meth:`~sdoml.sources.sdoml_gcs.SDOML_AIA_GCS` will be instantiated.
+where upon instantiation of the :py:meth:`~sdoml.sources.dataset_factory.DataSource`,
+if the instrument name is  ``aia``, the storage location ``gcs``, and the
+``.zarr`` file, ``sdomlv2_small.zarr``, :py:meth:`~sdoml.sources.sdoml_gcs.SDOML_AIA_GCS`
+will be instantiated.
 
 .. code-block:: python
 

--- a/examples/dataset/sdo_aia_dataset.ipynb
+++ b/examples/dataset/sdo_aia_dataset.ipynb
@@ -22,6 +22,8 @@
     "import matplotlib.pyplot as plt\n",
     "\n",
     "from sdoml import SDOMLDataset\n",
+    "from sdoml.sources import DataSource\n",
+    "\n",
     "from timeit import default_timer as timer"
    ]
   },
@@ -32,9 +34,25 @@
    "source": [
     "### Instantiate the `SDOMLDataset` class\n",
     "\n",
-    "First, we will instantiate the ``SDOMLDataset`` class, to load one month of \n",
-    "the six optically-thin SDO/AIA channels (94A/131A/171A/193A/211A/335A) \n",
-    "from ``fdl-sdoml-v2/sdomlv2_small.zarr``"
+    "First, we will instantiate the ``SDOMLDataset`` class, to load one month of the six optically-thin SDO/AIA channels (94, 131, 171, 193, 211, 335 Å) from ``fdl-sdoml-v2/sdomlv2_small.zarr``"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7d67217",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_to_load = {\n",
+    "    \"AIA\": {\n",
+    "        \"storage_location\": \"gcs\",\n",
+    "        \"root\": \"fdl-sdoml-v2/sdomlv2_small.zarr\",\n",
+    "        \"channels\": [\"94A\", \"131A\", \"171A\", \"193A\", \"211A\", \"335A\"],\n",
+    "    },\n",
+    "}\n",
+    "\n",
+    "datasource_arr = [DataSource(instrument=k, meta=v) for k, v in data_to_load.items()]"
    ]
   },
   {
@@ -45,17 +63,11 @@
    "outputs": [],
    "source": [
     "sdomlds = SDOMLDataset(\n",
-    "    cache_max_size=1 * 512 * 512 * 4096,\n",
+    "    cache_max_size=1 * 512 * 512 * 2048,\n",
     "    years=[\n",
     "        \"2010\",\n",
     "    ],\n",
-    "    data_to_load={\n",
-    "        \"AIA\": {\n",
-    "            \"storage_location\": \"gcs\",\n",
-    "            \"root\": \"fdl-sdoml-v2/sdomlv2_small.zarr\",\n",
-    "            \"channels\": [\"94A\", \"131A\", \"171A\", \"193A\", \"211A\", \"335A\"],\n",
-    "        },\n",
-    "    },\n",
+    "    data_to_load=datasource_arr,\n",
     ")"
    ]
   },
@@ -174,7 +186,7 @@
    "source": [
     "## Plotting\n",
     "\n",
-    "For the 211A channel, returned from the dataloader, the following code block creates a ``sunpy.map`` from the ``images`` and ``metadata``."
+    "For the 211 Å channel, returned from the dataloader, the following code block creates a ``sunpy.map`` from the ``images`` and ``metadata``."
    ]
   },
   {
@@ -234,6 +246,14 @@
     "\n",
     "        i += 1"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ebdd9e5b",
+   "metadata": {},
+   "source": [
+    "---"
+   ]
   }
  ],
  "metadata": {
@@ -252,7 +272,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.8.0"
   },
   "vscode": {
    "interpreter": {

--- a/examples/dataset/sdo_aia_dataset.ipynb
+++ b/examples/dataset/sdo_aia_dataset.ipynb
@@ -272,7 +272,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.0"
+   "version": "3.8.8"
   },
   "vscode": {
    "interpreter": {

--- a/examples/dataset/sdo_aiaeve_timeseries.ipynb
+++ b/examples/dataset/sdo_aiaeve_timeseries.ipynb
@@ -24,6 +24,8 @@
     "import pandas as pd\n",
     "\n",
     "from sdoml import SDOMLDataset\n",
+    "from sdoml.sources import DataSource\n",
+    "\n",
     "from timeit import default_timer as timer"
    ]
   },
@@ -39,27 +41,39 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "ec4c8b68",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_to_load = {\n",
+    "    \"AIA\": {\n",
+    "        \"storage_location\": \"gcs\",\n",
+    "        \"root\": \"fdl-sdoml-v2/sdomlv2_small.zarr/\",\n",
+    "        \"channels\": [\"94A\", \"193A\", \"211A\"],\n",
+    "    },\n",
+    "    \"EVE\": {\n",
+    "        \"storage_location\": \"gcs\",\n",
+    "        \"root\": \"fdl-sdoml-v2/sdomlv2_eve.zarr/\",\n",
+    "        \"channels\": [\"Fe XVIII\", \"Fe XII\", \"Fe XIV\"],\n",
+    "    },\n",
+    "}\n",
+    "\n",
+    "datasource_arr = [DataSource(instrument=k, meta=v) for k, v in data_to_load.items()]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "ee2923ee",
    "metadata": {},
    "outputs": [],
    "source": [
     "sdomlds = SDOMLDataset(\n",
-    "    cache_max_size=1 * 512 * 512 * 4096,\n",
+    "    cache_max_size=1 * 512 * 512 * 2048,\n",
     "    years=[\n",
     "        \"2010\",\n",
     "    ],\n",
-    "    data_to_load={\n",
-    "        \"AIA\": {\n",
-    "            \"storage_location\": \"gcs\",\n",
-    "            \"root\": \"fdl-sdoml-v2/sdomlv2_small.zarr/\",\n",
-    "            \"channels\": [\"94A\", \"193A\", \"211A\"],\n",
-    "        },\n",
-    "        \"EVE\": {\n",
-    "            \"storage_location\": \"gcs\",\n",
-    "            \"root\": \"fdl-sdoml-v2/sdomlv2_eve.zarr/\",\n",
-    "            \"channels\": [\"Fe XVIII\", \"Fe XII\", \"Fe XIV\"],\n",
-    "        },\n",
-    "    },\n",
+    "    data_to_load=datasource_arr,\n",
     ")"
    ]
   },
@@ -294,7 +308,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.8.0"
   },
   "vscode": {
    "interpreter": {

--- a/examples/dataset/sdo_aiahmi_dataset.ipynb
+++ b/examples/dataset/sdo_aiahmi_dataset.ipynb
@@ -22,6 +22,8 @@
     "import matplotlib.pyplot as plt\n",
     "\n",
     "from sdoml import SDOMLDataset\n",
+    "from sdoml.sources import DataSource\n",
+    "\n",
     "from timeit import default_timer as timer"
    ]
   },
@@ -40,27 +42,39 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "9c7e71d2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_to_load = {\n",
+    "    \"AIA\": {\n",
+    "        \"storage_location\": \"gcs\",\n",
+    "        \"root\": \"fdl-sdoml-v2/sdomlv2_small.zarr\",\n",
+    "        \"channels\": [\"94A\", \"131A\", \"171A\", \"193A\", \"211A\", \"335A\"],\n",
+    "    },\n",
+    "    \"HMI\": {\n",
+    "        \"storage_location\": \"gcs\",\n",
+    "        \"root\": \"fdl-sdoml-v2/sdomlv2_hmi_small.zarr\",\n",
+    "        \"channels\": [\"Bx\", \"By\", \"Bz\"],\n",
+    "    },\n",
+    "}\n",
+    "\n",
+    "datasource_arr = [DataSource(instrument=k, meta=v) for k, v in data_to_load.items()]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "c86e164d",
    "metadata": {},
    "outputs": [],
    "source": [
     "sdomlds = SDOMLDataset(\n",
-    "    cache_max_size=1 * 512 * 512 * 4096,\n",
+    "    cache_max_size=1 * 512 * 512 * 2048,\n",
     "    years=[\n",
     "        \"2010\",\n",
     "    ],\n",
-    "    data_to_load={\n",
-    "        \"AIA\": {\n",
-    "            \"storage_location\": \"gcs\",\n",
-    "            \"root\": \"fdl-sdoml-v2/sdomlv2_small.zarr\",\n",
-    "            \"channels\": [\"94A\", \"131A\", \"171A\", \"193A\", \"211A\", \"335A\"],\n",
-    "        },\n",
-    "        \"HMI\": {\n",
-    "            \"storage_location\": \"gcs\",\n",
-    "            \"root\": \"fdl-sdoml-v2/sdomlv2_hmi_small.zarr\",\n",
-    "            \"channels\": [\"Bx\", \"By\", \"Bz\"],\n",
-    "        },\n",
-    "    },\n",
+    "    data_to_load=datasource_arr,\n",
     ")"
    ]
   },
@@ -171,7 +185,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.8.0"
   },
   "vscode": {
    "interpreter": {

--- a/sdoml/dataloader.py
+++ b/sdoml/dataloader.py
@@ -42,29 +42,8 @@ class SDOMLDataset(Dataset):
         See [here](https://pandas.pydata.org/docs/user_guide/timeseries.html#timeseries-offset-aliases)
         for a list of frequency aliases. By default this is ``120T`` (120 minutes)
 
-    data_to_load : Dict[str, Dict[str]]
-        A dictionary of instruments dictionaries to include.
-
-        Valid instruments :
-            - `AIA` : SDO Atomospheric Imaging Assembly
-            - `HMI` : SDO Helioseismic and Magnetic Imager
-            - `EVE` : Extreme UltraViolet Variability Experiment
-
-        Each instrument dictionary requires the following keys:
-
-        - storage_location: str
-            Storage location of the file.
-
-            Options :
-                - ``gcs`` : Google Cloud Storage
-
-        - root: str
-            Location of the root ``.zarr`` file within the ``storage_location``.
-            By default this is ``fdl-sdoml-v2/sdomlv2_small.zarr/`` (which is
-            located on Google Cloud Storage ``storage_location == gcs``).
-
-        - channels: List[str]
-            A list of channels to include from each instrument.
+    data_to_load : List[``~sdoml.sources.dataset_factory.DataSource``]
+        A list of ``~sdoml.sources.dataset_factory.DataSource``
 
     Examples
     --------
@@ -74,23 +53,7 @@ class SDOMLDataset(Dataset):
         sdomlds = SDOMLDataset(
             cache_max_size=1 * 512 * 512 * 4096,
             years=["2010", "2011"],
-            data_to_load={
-                    "HMI": {
-                        "storage_location": "gcs",
-                        "root": "fdl-sdoml-v2/sdomlv2_hmi_small.zarr/",
-                        "channels": ["Bx", "By", "Bz"],
-                        },
-                    "AIA": {
-                        "storage_location": "gcs",
-                        "root": "fdl-sdoml-v2/sdomlv2_small.zarr/",
-                        "channels": ["94A", "131A", "171A", "193A", "211A", "335A"],
-                        },
-                    "EVE": {
-                        "storage_location": "gcs",
-                        "root": "fdl-sdoml-v2/sdomlv2_eve.zarr/",
-                        "channels": ["O V", "Mg X", "Fe XI"],
-                    },
-                },
+            data_to_load=[...]
             )
     """
 
@@ -99,7 +62,7 @@ class SDOMLDataset(Dataset):
         cache_max_size: Optional[int] = 1 * 512 * 512 * 2048,
         years: Optional[List[str]] = None,
         freq: str = "120T",
-        data_to_load: Optional[List[str]] = None,
+        data_to_load: List[DataSource] = None,
     ):
 
         # !TODO implement passing of ``selected_times`` and ``required_keys``
@@ -115,10 +78,11 @@ class SDOMLDataset(Dataset):
         self._meta = data_to_load
 
         # instantiate the appropriate classes
-        data_arr = [
-            DataSource(k, v, self._years, self._single_cache_max_size)
-            for k, v in data_to_load.items()
-        ]
+        data_arr = data_to_load  # !TODO remove before MR
+        # data_arr = [
+        #     DataSource(k, v, self._years, self._single_cache_max_size)
+        #     for k, v in data_to_load.items()
+        # ]
 
         # !TODO rearrange data for cadence (lowest to highest)
 

--- a/sdoml/dataloader.py
+++ b/sdoml/dataloader.py
@@ -11,7 +11,7 @@ import pandas as pd
 import torch
 from torch.utils.data import Dataset
 
-from sdoml.sources.dataset_factory import DataSource
+from sdoml.sources import DataSource
 
 __all__ = ["SDOMLDataset"]
 
@@ -39,40 +39,47 @@ class SDOMLDataset(Dataset):
 
     freq : Optional[Union[str, None]]
         A string representing the frequency at which data should be obtained.
-        See [here](https://pandas.pydata.org/docs/user_guide/timeseries.html#timeseries-offset-aliases)
+        See :ref:`pandas docs <https://pandas.pydata.org/docs/user_guide/timeseries.html#timeseries-offset-aliases>`__
         for a list of frequency aliases. By default this is ``120T`` (120 minutes)
 
-    data_to_load : List[``~sdoml.sources.dataset_factory.DataSource``]
-        A list of :py:meth:``~sdoml.sources.dataset_factory.DataSource``
+    data_to_load : List[:py:meth:`~sdoml.sources.DataSource`]
+        A list of :py:meth:`~sdoml.sources.DataSource` objects
 
-    Examples
-    --------
+    Example
+    -------
 
-    .. code-block:: python
+    Define the data that we would like. For simplicity, this is is written as
+    a nested dictionary, with each instrument having a dictionary that contains
+    the ``storage_location``, ``root`` ``.zarr`` file, and ``channels`` required.
 
-        data_to_load = {
-            "HMI": {
-                "storage_location": "gcs",
-                "root": "fdl-sdoml-v2/sdomlv2_hmi_small.zarr/",
-                "channels": ["Bx", "By", "Bz"],
-            },
-            "AIA": {
-                "storage_location": "gcs",
-                "root": "fdl-sdoml-v2/sdomlv2_small.zarr/",
-                "channels": ["94A", "131A", "171A", "193A", "211A", "335A"],
-            },
-        }
+    >>> data_to_load = {
+    ...     "HMI": {
+    ...         "storage_location": "gcs",
+    ...         "root": "fdl-sdoml-v2/sdomlv2_hmi_small.zarr/",
+    ...         "channels": ["Bx", "By", "Bz"],
+    ...     },
+    ...     "AIA": {
+    ...         "storage_location": "gcs",
+    ...         "root": "fdl-sdoml-v2/sdomlv2_small.zarr/",
+    ...         "channels": ["94A", "131A", "171A", "193A", "211A", "335A"],
+    ...     },
+    ... }
 
-        data_arr = [
-            DataSource(instrument=k, meta=v) for k, v in data_to_load.items()
-        ]
+    Utilising :py:meth:`~sdoml.sources.DataSource`, ``datasource_arr`` is a `List`
+    of ``DataSource`` objects
 
-        sdomlds = SDOMLDataset(
-            cache_max_size=1 * 512 * 512 * 4096,
-            years=["2010", "2011"],
-            data_to_load=data_arr
-            )
+    >>> datasource_arr = [
+    ...         DataSource(instrument=k, meta=v) for k, v in data_to_load.items()
+    ...     ]
 
+    ``datasource_arr`` is passed to :py:meth:`~sdoml.dataloader.SDOMLDataset`, along
+    with the maximum cache size (``cache_max_size``), and years requested (``years``)
+
+    >>> sdomlds = SDOMLDataset(
+    ...         cache_max_size=1 * 512 * 512 * 4096,
+    ...         years=["2010", "2011"],
+    ...         data_to_load=datasource_arr,
+    ...     )
 
     """
 

--- a/sdoml/dataloader.py
+++ b/sdoml/dataloader.py
@@ -39,7 +39,7 @@ class SDOMLDataset(Dataset):
 
     freq : Optional[Union[str, None]]
         A string representing the frequency at which data should be obtained.
-        See :ref:`pandas docs <https://pandas.pydata.org/docs/user_guide/timeseries.html#timeseries-offset-aliases>`__
+        See https://pandas.pydata.org/docs/user_guide/timeseries.html#timeseries-offset-aliases
         for a list of frequency aliases. By default this is ``120T`` (120 minutes)
 
     data_to_load : List[:py:meth:`~sdoml.sources.DataSource`]
@@ -102,11 +102,12 @@ class SDOMLDataset(Dataset):
         self._single_cache_max_size = self._cache_max_size / len(data_to_load)
         self._years = years
 
-        d = {}
-        for item in data_to_load:
-            d = {**d, **{item._instrument: item._meta}}
-
-        self._meta = d.copy()
+        # create a dictionary of dictionaries from ``data_to_load``
+        self._meta = {}
+        [
+            self._meta.update(**{item._instrument: item._meta})
+            for item in data_to_load
+        ]
 
         # instantiate the appropriate classes
         data_arr = data_to_load  # !TODO remove before MR

--- a/sdoml/sources/__init__.py
+++ b/sdoml/sources/__init__.py
@@ -25,4 +25,5 @@ see :py:meth:`~sdoml.sources.sdoml_gcs`.
 """
 
 from .data_base import *
+from .dataset_factory import *
 from .sdoml_gcs import *

--- a/sdoml/sources/data_base.py
+++ b/sdoml/sources/data_base.py
@@ -67,6 +67,9 @@ class GenericDataSource(ABC):
         # want to do checks here...
         self._instrument = instrument
         self._meta = meta
+
+        # !TODO I feel like we can address these later on;
+        # ... they can just be set by the dataloader
         self._requested_years = sorted(years)
         self._cache_size = cache_size
 

--- a/sdoml/sources/data_base.py
+++ b/sdoml/sources/data_base.py
@@ -59,8 +59,6 @@ class GenericDataSource(ABC):
         self,
         instrument: str,
         meta: Dict,
-        # years: List,
-        # cache_size: int,
         **kwargs,
     ) -> None:
 

--- a/sdoml/sources/data_base.py
+++ b/sdoml/sources/data_base.py
@@ -23,9 +23,9 @@ class GenericDataSource(ABC):
     """
     Generic DataSource Class to be inherited by specific DataSource classes.
 
-    The following attributes should be set in the child class:
+    The following attributes should be set in the subclass:
 
-    .. code-block :: python
+    .. code-block:: python
 
         self._time_format : str                 # e.g. %Y-%m-%dT%H:%M:%S.%fZ
 
@@ -73,7 +73,7 @@ class GenericDataSource(ABC):
         self._requested_years = None  # sorted(years)
         self._cache_size = None  # cache_size
 
-        #  -- Set some attributes that need to be updated in the child classes
+        #  -- Set some attributes that need to be updated in the subclasses
         #
         self._time_format: str
         #
@@ -355,6 +355,6 @@ class GenericDataSource(ABC):
     @abstractmethod
     def datasource(cls) -> bool:
         """
-        Determines if the child class should be instantiated
+        Determines if the subclass should be instantiated
         """
         return NotImplementedError

--- a/sdoml/sources/data_base.py
+++ b/sdoml/sources/data_base.py
@@ -59,8 +59,8 @@ class GenericDataSource(ABC):
         self,
         instrument: str,
         meta: Dict,
-        years: List,
-        cache_size: int,
+        # years: List,
+        # cache_size: int,
         **kwargs,
     ) -> None:
 
@@ -70,8 +70,8 @@ class GenericDataSource(ABC):
 
         # !TODO I feel like we can address these later on;
         # ... they can just be set by the dataloader
-        self._requested_years = sorted(years)
-        self._cache_size = cache_size
+        self._requested_years = None  # sorted(years)
+        self._cache_size = None  # cache_size
 
         #  -- Set some attributes that need to be updated in the child classes
         #

--- a/sdoml/sources/dataset_factory.py
+++ b/sdoml/sources/dataset_factory.py
@@ -52,7 +52,7 @@ class DataSourceFactory(BasicRegistrationFactory):
     factory.
     """
 
-    def __call__(self, instrument, meta, years, cache_size, **kwargs):
+    def __call__(self, instrument, meta, **kwargs):
         """
         This function iterates over each registered type,
         checking to see if WidgetType matches the arguments.
@@ -63,7 +63,7 @@ class DataSourceFactory(BasicRegistrationFactory):
 
         try:
             new_datum = self._check_registered_widgets(
-                instrument, meta, years, cache_size, **kwargs
+                instrument, meta, **kwargs
             )
             new_data.append(new_datum)
         except (NoMatchError, MultipleMatchError) as e:
@@ -72,9 +72,7 @@ class DataSourceFactory(BasicRegistrationFactory):
         if len(new_data) == 1:
             return new_data[0]
 
-    def _check_registered_widgets(
-        self, instrument, meta, years, cache_size, **kwargs
-    ):
+    def _check_registered_widgets(self, instrument, meta, **kwargs):
         """
         Implementation of a basic check to see if arguments match a widget.
         """
@@ -105,7 +103,7 @@ class DataSourceFactory(BasicRegistrationFactory):
         # Only one is found
         WidgetType = candidate_widget_types[0]
 
-        return WidgetType(instrument, meta, years, cache_size, **kwargs)
+        return WidgetType(instrument, meta, **kwargs)
 
 
 DataSource = DataSourceFactory(

--- a/sdoml/sources/sdoml_gcs.py
+++ b/sdoml/sources/sdoml_gcs.py
@@ -50,14 +50,14 @@ class SDOML_AIA_GCS(GenericDataSource):
 
     """
 
-    def __init__(self, instrument, meta, years, cache_size, **kwargs):
+    def __init__(self, instrument, meta, **kwargs):
         """
 
         Parameters
         ----------
 
         """
-        super().__init__(instrument, meta, years, cache_size, **kwargs)
+        super().__init__(instrument, meta, **kwargs)
 
         # Set the time format of the data
         self._time_format = "%Y-%m-%dT%H:%M:%S.%fZ"
@@ -77,6 +77,9 @@ class SDOML_AIA_GCS(GenericDataSource):
         """
 
         yc_dict = {}
+
+        if self._requested_years is None:
+            raise ValueError("No years requested.")
 
         # go through years, and channels ensuring we can read the data
         for i, channel in enumerate(self._meta["channels"]):
@@ -142,6 +145,9 @@ class SDOML_AIA_GCS(GenericDataSource):
         """
         super().load_data_meta()
 
+        if self._cache_size is None:
+            raise ValueError("``self._cache_size`` is None")
+
         by_year, meta_yr = [], []
         for yr in self._available_years:
             data = [
@@ -198,14 +204,14 @@ class SDOML_HMI_GCS(SDOML_AIA_GCS):
             └── Bz (25540, 512, 512) float32
     """
 
-    def __init__(self, instrument, meta, years, cache_size, **kwargs):
+    def __init__(self, instrument, meta, **kwargs):
         """
 
         Parameters
         ----------
 
         """
-        super().__init__(instrument, meta, years, cache_size, **kwargs)
+        super().__init__(instrument, meta, **kwargs)
 
         # Main difference between AIA and HMI data is the time format.
         self._time_format = "%Y.%m.%d_%H:%M:%S_TAI"
@@ -243,14 +249,14 @@ class SDOML_EVE_GCS(GenericDataSource):
             └── Time (2137380,) <U23
     """
 
-    def __init__(self, instrument, meta, years, cache_size=None, **kwargs):
+    def __init__(self, instrument, meta, **kwargs):
         """
 
         Parameters
         ----------
 
         """
-        super().__init__(instrument, meta, years, cache_size=None, **kwargs)
+        super().__init__(instrument, meta, **kwargs)
 
         # set the time_format
         self._time_format = "%Y-%m-%d %H:%M:%S.%f"
@@ -268,6 +274,9 @@ class SDOML_EVE_GCS(GenericDataSource):
 
         # The data is not stored per-year, but instead already combined
         yc_dict = {"all": []}
+
+        if self._requested_years is None:
+            raise ValueError("No years requested.")
 
         for channel in self._meta["channels"]:
             path_to_data = os.path.join(self._meta["root"], "MEGS-A", channel)
@@ -302,6 +311,9 @@ class SDOML_EVE_GCS(GenericDataSource):
                 e.g. ``time_yr[year_index][channel_index]``
         """
         super().load_data_meta()
+
+        if self._cache_size is None:
+            raise ValueError("``self._cache_size`` is None")
 
         loaded_data = [
             load_single_gcs_zarr(

--- a/sdoml/version.py
+++ b/sdoml/version.py
@@ -7,4 +7,4 @@ try:
     __version__ = get_version(root="..", relative_to=__file__)
 
 except Exception:
-    __version__ = "0.1.dev42+gfc37a40.d20220807"
+    __version__ = "0.1.dev16+g5db4c84.d20221101"

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,7 @@ docs =
     nbsphinx
     sphinx_copybutton
     nbsphinx_link
+    sphinx-toggleprompt
 
 [tool:pytest]
 testpaths = "sdoml" "docs"

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ console_scripts =
 [options.extras_require]
 all =
 test =
+    nb-black
     pytest
     pytest-doctestplus
     pytest-cov


### PR DESCRIPTION
Refactor the dataloader to now instantiate the ``DataSource``.

Justification: It is potentially clearer to instantiate the set of ``DataSource`` objects outside of the ``SDOMLDataset``. If there are connection issues due to incorrect credentials, this should be raised before attempting to load any data.